### PR TITLE
important filename case-sensitivity fix

### DIFF
--- a/src/WiFiEsp.h
+++ b/src/WiFiEsp.h
@@ -4,7 +4,7 @@
 
 #include <inttypes.h>
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "IPAddress.h"
 
 


### PR DESCRIPTION
On a case-sensitive filesystem the included file must be named "Arduino.h".