### PR TITLE
Fixes to enable WiFiEsp on Arduino Due and other SAM32 chips.

### DIFF
--- a/src/WiFiEsp.h
+++ b/src/WiFiEsp.h
@@ -28,7 +28,7 @@ along with The Arduino WiFiEsp library.  If not, see
 #include "WiFiEspClient.h"
 #include "WiFiEspServer.h"
 #include "utility/EspDrv.h"
-#include "utility/RingBuffer.h"
+#include "utility/WifiEspRingBuffer.h"
 #include "utility/debug.h"
 
 

--- a/src/utility/EspDrv.cpp
+++ b/src/utility/EspDrv.cpp
@@ -46,7 +46,7 @@ typedef enum
 
 Stream *EspDrv::espSerial;
 
-RingBuffer EspDrv::ringBuf(32);
+WifiEspRingBuffer EspDrv::ringBuf(32);
 
 // Array of data to cache the information related to the networks discovered
 char 	EspDrv::_networkSsid[][WL_SSID_MAX_LENGTH] = {{"1"},{"2"},{"3"},{"4"},{"5"}};
@@ -871,7 +871,7 @@ int EspDrv::sendCmd(const __FlashStringHelper* cmd, int timeout, ...)
 
 	va_list args;
 	va_start (args, timeout);
-	vsnprintf_P (cmdBuf, CMD_BUFFER_SIZE, (char*)cmd, args);
+	vsnprintf (cmdBuf, CMD_BUFFER_SIZE, (char*)cmd, args);
 	va_end (args);
 
 	espEmptyBuf();

--- a/src/utility/EspDrv.h
+++ b/src/utility/EspDrv.h
@@ -23,7 +23,7 @@ along with The Arduino WiFiEsp library.  If not, see
 #include "IPAddress.h"
 
 
-#include "RingBuffer.h"
+#include "WifiEspRingBuffer.h"
 
 
 
@@ -304,7 +304,7 @@ private:
 
 
 	// the ring buffer is used to search the tags in the stream
-	static RingBuffer ringBuf;
+	static WifiEspRingBuffer ringBuf;
 
 
 	//static int sendCmd(const char* cmd, int timeout=1000);

--- a/src/utility/WifiEspRingBuffer.cpp
+++ b/src/utility/WifiEspRingBuffer.cpp
@@ -16,11 +16,11 @@ along with The Arduino WiFiEsp library.  If not, see
 <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------*/
 
-#include "RingBuffer.h"
+#include "WifiEspRingBuffer.h"
 
 #include <Arduino.h>
 
-RingBuffer::RingBuffer(unsigned int size)
+WifiEspRingBuffer::WifiEspRingBuffer(unsigned int size)
 {
 	_size = size;
 	// add one char to terminate the string
@@ -29,20 +29,20 @@ RingBuffer::RingBuffer(unsigned int size)
 	init();
 }
 
-RingBuffer::~RingBuffer() {}
+WifiEspRingBuffer::~WifiEspRingBuffer() {}
 
-void RingBuffer::reset()
+void WifiEspRingBuffer::reset()
 {
 	ringBufP = ringBuf;
 }
 
-void RingBuffer::init()
+void WifiEspRingBuffer::init()
 {
 	ringBufP = ringBuf;
 	memset(ringBuf, 0, _size+1);
 }
 
-void RingBuffer::push(char c)
+void WifiEspRingBuffer::push(char c)
 {
 	*ringBufP = c;
 	ringBufP++;
@@ -52,7 +52,7 @@ void RingBuffer::push(char c)
 
 
 
-bool RingBuffer::endsWith(const char* str)
+bool WifiEspRingBuffer::endsWith(const char* str)
 {
 	int findStrLen = strlen(str);
 
@@ -79,7 +79,7 @@ bool RingBuffer::endsWith(const char* str)
 
 
 
-void RingBuffer::getStr(char * destination, unsigned int skipChars)
+void WifiEspRingBuffer::getStr(char * destination, unsigned int skipChars)
 {
   int len = ringBufP-ringBuf-skipChars;
 

--- a/src/utility/WifiEspRingBuffer.h
+++ b/src/utility/WifiEspRingBuffer.h
@@ -16,15 +16,15 @@ along with The Arduino WiFiEsp library.  If not, see
 <http://www.gnu.org/licenses/>.
 --------------------------------------------------------------------*/
 
-#ifndef RingBuffer_h
-#define RingBuffer_h
+#ifndef WifiEspWifiEspRingBuffer_h
+#define WifiEspWifiEspRingBuffer_h
 
 
-class RingBuffer
+class WifiEspRingBuffer
 {
 public:
-	RingBuffer(unsigned int size);
-	~RingBuffer();
+	WifiEspRingBuffer(unsigned int size);
+	~WifiEspRingBuffer();
 
 	void reset();
 	void init();

--- a/src/utility/debug.h
+++ b/src/utility/debug.h
@@ -28,7 +28,7 @@ along with The Arduino WiFiEsp library.  If not, see
 // 3: INFO: errors, warnings and informational (default)
 // 4: DEBUG: errors, warnings, informational and debug
 
-#define _ESPLOGLEVEL_ 3
+#define _ESPLOGLEVEL_ 4
 
 
 #define LOGERROR(x)    if(_ESPLOGLEVEL_>0) { Serial.print("[WiFiEsp] "); Serial.println(x); }


### PR DESCRIPTION
Fixes issue #26 

Problem is SAM32 libs already contain RingBuffer used for the UART. Renamed the class and removed vsnprintf_P usage as its only present on AVRs.