### PR TITLE
Logging disabled by default

### DIFF
--- a/src/utility/debug.h
+++ b/src/utility/debug.h
@@ -28,7 +28,7 @@ along with The Arduino WiFiEsp library.  If not, see
 // 3: INFO: errors, warnings and informational (default)
 // 4: DEBUG: errors, warnings, informational and debug
 
-#define _ESPLOGLEVEL_ 3
+#define _ESPLOGLEVEL_ 0
 
 
 #define LOGERROR(x)    if(_ESPLOGLEVEL_>0) { Serial.print("[WiFiEsp] "); Serial.println(x); }


### PR DESCRIPTION
This allows use with ESP8266 connected to Serial without needing to edit the library, reduces memory usage and decreases execution times.
