### PR TITLE
Correct incoming client socket management

### DIFF
--- a/src/WiFiEsp.cpp
+++ b/src/WiFiEsp.cpp
@@ -206,5 +206,28 @@ bool WiFiEspClass::ping(const char *host)
 	return EspDrv::ping(host);
 }
 
+static uint8_t WiFiEspClass::getFreeSocket()
+{
+  // ESP Module assigns socket numbers in ascending order, so we will assign them in descending order
+    for (int i = MAX_SOCK_NUM - 1; i >= 0; i--)
+	{
+      if (_state[i] == NA_STATE)
+      {
+          return i;
+      }
+    }
+    return SOCK_NOT_AVAIL;
+}
+
+static void WiFiEspClass::allocateSocket(uint8_t sock)
+{
+  _state[sock] = sock;
+}
+
+static void WiFiEspClass::releaseSocket(uint8_t sock)
+{
+  _state[sock] = NA_STATE;
+}
+
 
 WiFiEspClass WiFi;

--- a/src/WiFiEsp.h
+++ b/src/WiFiEsp.h
@@ -259,6 +259,7 @@ public:
 
 	friend class WiFiEspClient;
 	friend class WiFiEspServer;
+	friend class WiFiEspUDP;
 
 private:
 	static uint8_t getFreeSocket();

--- a/src/WiFiEsp.h
+++ b/src/WiFiEsp.h
@@ -261,6 +261,10 @@ public:
 	friend class WiFiEspServer;
 
 private:
+	static uint8_t getFreeSocket();
+	static void allocateSocket(uint8_t sock);
+	static void releaseSocket(uint8_t sock);
+
 	static uint8_t espMode;
 };
 

--- a/src/WiFiEspClient.h
+++ b/src/WiFiEspClient.h
@@ -135,7 +135,6 @@ private:
 
   uint8_t _sock;     // connection id
 
-  uint8_t getFirstSocket();
   int connect(const char* host, uint16_t port, uint8_t protMode);
   
   size_t printFSH(const __FlashStringHelper *ifsh, bool appendCrLf);

--- a/src/WiFiEspServer.cpp
+++ b/src/WiFiEspServer.cpp
@@ -32,7 +32,20 @@ void WiFiEspServer::begin()
 {
 	LOGDEBUG(F("Starting server"));
 
-	_started = EspDrv::startServer(_port);
+	/* The ESP Module only allows socket 1 to be used for the server */
+#if 0
+	_sock = WiFiEspClass::getFreeSocket();
+	if (_sock == SOCK_NOT_AVAIL)
+	  {
+	    LOGERROR(F("No socket available for server"));
+	    return;
+	  }
+#else
+	_sock = 1; // If this is already in use, the startServer attempt will fail
+#endif
+	WiFiEspClass::allocateSocket(_sock);
+
+	_started = EspDrv::startServer(_port, _sock);
 
 	if (_started)
 	{
@@ -52,6 +65,7 @@ WiFiEspClient WiFiEspServer::available(byte* status)
 	if (bytes>0)
 	{
 		LOGINFO1(F("New client"), EspDrv::_connId);
+		WiFiEspClass::allocateSocket(EspDrv::_connId);
 		WiFiEspClient client(EspDrv::_connId);
 		return client;
 	}

--- a/src/WiFiEspServer.h
+++ b/src/WiFiEspServer.h
@@ -55,6 +55,7 @@ public:
 
 private:
 	uint16_t _port;
+	uint8_t _sock;
 	bool _started;
 
 };

--- a/src/WiFiEspUdp.cpp
+++ b/src/WiFiEspUdp.cpp
@@ -32,7 +32,7 @@ WiFiEspUDP::WiFiEspUDP() : _sock(NO_SOCKET_AVAIL) {}
 
 uint8_t WiFiEspUDP::begin(uint16_t port)
 {
-    uint8_t sock = getFirstSocket();
+    uint8_t sock = WiFiEspClass::getFreeSocket();
     if (sock != NO_SOCKET_AVAIL)
     {
         EspDrv::startClient("0", port, sock, UDP_MODE);
@@ -77,13 +77,13 @@ void WiFiEspUDP::stop()
 int WiFiEspUDP::beginPacket(const char *host, uint16_t port)
 {
   if (_sock == NO_SOCKET_AVAIL)
-	  _sock = getFirstSocket();
+	  _sock = WiFiEspClass::getFreeSocket();
   if (_sock != NO_SOCKET_AVAIL)
   {
 	  //EspDrv::startClient(host, port, _sock, UDP_MODE);
 	  _remotePort = port;
 	  strcpy(_remoteHost, host);
-	  WiFiEspClass::_state[_sock] = _sock;
+	  WiFiEspClass::allocateSocket(_sock);
 	  return 1;
   }
   return 0;
@@ -177,17 +177,4 @@ uint16_t  WiFiEspUDP::remotePort()
 // Private Methods
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO remove duplication with WiFiEspClient::getFirstSocket()
-
-uint8_t WiFiEspUDP::getFirstSocket()
-{
-    for (int i = 0; i < MAX_SOCK_NUM; i++)
-	{
-      if (WiFiEspClass::_state[i] == NA_STATE)
-      {
-          return i;
-      }
-    }
-    return SOCK_NOT_AVAIL;
-}
 

--- a/src/WiFiEspUdp.h
+++ b/src/WiFiEspUdp.h
@@ -90,8 +90,6 @@ public:
   // Return the port of the host who sent the current incoming packet
   virtual uint16_t remotePort();
 
-  uint8_t getFirstSocket();
-
 
   friend class WiFiEspServer;
 };

--- a/src/utility/EspDrv.cpp
+++ b/src/utility/EspDrv.cpp
@@ -586,11 +586,11 @@ bool EspDrv::ping(const char *host)
 
 
 // Start server TCP on port specified
-bool EspDrv::startServer(uint16_t port)
+bool EspDrv::startServer(uint16_t port, uint8_t sock)
 {
 	LOGDEBUG1(F("> startServer"), port);
 
-	int ret = sendCmd(F("AT+CIPSERVER=1,%d"), 1000, port);
+	int ret = sendCmd(F("AT+CIPSERVER=%d,%d"), 1000, sock, port);
 
 	return ret==TAG_OK;
 }

--- a/src/utility/EspDrv.h
+++ b/src/utility/EspDrv.h
@@ -263,7 +263,7 @@ public:
 	////////////////////////////////////////////////////////////////////////////
 
 
-	static bool startServer(uint16_t port);
+    static bool startServer(uint16_t port, uint8_t sock);
     static bool startClient(const char* host, uint16_t port, uint8_t sock, uint8_t protMode);
     static void stopClient(uint8_t sock);
     static uint8_t getServerState(uint8_t sock);


### PR DESCRIPTION
This pull request is to fix issue #60.  It contains four commits: the library is consistent and still works between each commit.

The first commit creates the infrastructure for the fix by adding socket management in the WiFiEsp class.

The second commit contains the actual fix for issue #60: it adds tracking of socket usage for the server itself and for the clients for incoming connections. This allows incoming and outgoing connections to be mixed, up to the limit of the connection IDs the ESP can manage.

The last two commits change the other classes to use the new infrastructure instead of accessing the WiFiESP private data directly.
