### PR TITLE
Fixing Issue #69 (Can't declare member function to have static linkage)

### DIFF
--- a/src/WiFiEsp.cpp
+++ b/src/WiFiEsp.cpp
@@ -206,7 +206,7 @@ bool WiFiEspClass::ping(const char *host)
 	return EspDrv::ping(host);
 }
 
-static uint8_t WiFiEspClass::getFreeSocket()
+uint8_t WiFiEspClass::getFreeSocket()
 {
   // ESP Module assigns socket numbers in ascending order, so we will assign them in descending order
     for (int i = MAX_SOCK_NUM - 1; i >= 0; i--)
@@ -219,12 +219,12 @@ static uint8_t WiFiEspClass::getFreeSocket()
     return SOCK_NOT_AVAIL;
 }
 
-static void WiFiEspClass::allocateSocket(uint8_t sock)
+void WiFiEspClass::allocateSocket(uint8_t sock)
 {
   _state[sock] = sock;
 }
 
-static void WiFiEspClass::releaseSocket(uint8_t sock)
+void WiFiEspClass::releaseSocket(uint8_t sock)
 {
   _state[sock] = NA_STATE;
 }


### PR DESCRIPTION
The problem is in incorrect signature of static functions.
Explanation in
http://stackoverflow.com/questions/8130066/static-member-functions-error-how-to-properly-write-the-signature