### PR TITLE
Support fw 2

### DIFF
--- a/src/WiFiEsp.cpp
+++ b/src/WiFiEsp.cpp
@@ -206,7 +206,7 @@ bool WiFiEspClass::ping(const char *host)
 	return EspDrv::ping(host);
 }
 
-static uint8_t WiFiEspClass::getFreeSocket()
+uint8_t WiFiEspClass::getFreeSocket()
 {
   // ESP Module assigns socket numbers in ascending order, so we will assign them in descending order
     for (int i = MAX_SOCK_NUM - 1; i >= 0; i--)
@@ -219,12 +219,12 @@ static uint8_t WiFiEspClass::getFreeSocket()
     return SOCK_NOT_AVAIL;
 }
 
-static void WiFiEspClass::allocateSocket(uint8_t sock)
+void WiFiEspClass::allocateSocket(uint8_t sock)
 {
   _state[sock] = sock;
 }
 
-static void WiFiEspClass::releaseSocket(uint8_t sock)
+void WiFiEspClass::releaseSocket(uint8_t sock)
 {
   _state[sock] = NA_STATE;
 }

--- a/src/utility/EspDrv.cpp
+++ b/src/utility/EspDrv.cpp
@@ -97,8 +97,8 @@ void EspDrv::wifiDriverInit(Stream *espSerial)
 	// check firmware version
 	getFwVersion();
 
-	// prints a warning message if the firmware is not 1.X
-	if (fwVersion[0] != '1' or
+	// prints a warning message if the firmware is not 1.X or 2.X
+	if ((fwVersion[0] != '1' and fwVersion[0] != '2') or
 		fwVersion[1] != '.')
 	{
 		LOGWARN1(F("Warning: Unsupported firmware"), fwVersion);


### PR DESCRIPTION
Supporting ESP8266 firmware 2.X

The newest fw is now 2.0. This patch recognizes this fw as valid.