### PR TITLE
Get rid of Serial dependency

### DIFF
--- a/src/WiFiEspClient.cpp
+++ b/src/WiFiEspClient.cpp
@@ -66,7 +66,7 @@ int WiFiEspClient::connectSSL(const char* host, uint16_t port)
 int WiFiEspClient::connectSSL(IPAddress ip, uint16_t port)
 {
 	char s[16];
-	sprintf(s, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	sprintf_P(s, PSTR("%d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
 	return connect(s, port, SSL_MODE);
 }
 
@@ -78,7 +78,7 @@ int WiFiEspClient::connect(const char* host, uint16_t port)
 int WiFiEspClient::connect(IPAddress ip, uint16_t port)
 {
 	char s[16];
-	sprintf(s, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	sprintf_P(s, PSTR("%d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
 
 	return connect(s, port, TCP_MODE);
 }

--- a/src/WiFiEspClient.cpp
+++ b/src/WiFiEspClient.cpp
@@ -99,7 +99,7 @@ int WiFiEspClient::connect(const char* host, uint16_t port, uint8_t protMode)
     }
 	else
 	{
-    	Serial.println(F("No socket available"));
+    	LOGERROR(F("No socket available"));
     	return 0;
     }
     return 1;

--- a/src/WiFiEspUdp.cpp
+++ b/src/WiFiEspUdp.cpp
@@ -100,7 +100,7 @@ int WiFiEspUDP::beginPacket(const char *host, uint16_t port)
 int WiFiEspUDP::beginPacket(IPAddress ip, uint16_t port)
 {
 	char s[18];
-	sprintf(s, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	sprintf_P(s, PSTR("%d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
 
 	return beginPacket(s, port);
 }

--- a/src/utility/EspDrv.cpp
+++ b/src/utility/EspDrv.cpp
@@ -230,7 +230,7 @@ void EspDrv::config(IPAddress ip)
 	delay(500);
 	
 	char buf[16];
-	sprintf(buf, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	sprintf_P(buf, PSTR("%d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
 
 	int ret = sendCmd(F("AT+CIPSTA_CUR=\"%s\""), 2000, buf);
 	delay(500);
@@ -254,7 +254,7 @@ void EspDrv::configAP(IPAddress ip)
 	delay(500);
 	
 	char buf[16];
-	sprintf(buf, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
+	sprintf_P(buf, PSTR("%d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
 
 	int ret = sendCmd(F("AT+CIPAP_CUR=\"%s\""), 2000, buf);
 	delay(500);


### PR DESCRIPTION
This is probably a leftover from initial development stages that brings in the whole HardwareSerial object whenever the library is used.