### PR TITLE
Add support for hard reset through dedicated pin.

### DIFF
--- a/src/utility/EspDrv.cpp
+++ b/src/utility/EspDrv.cpp
@@ -72,6 +72,14 @@ void EspDrv::wifiDriverInit(Stream *espSerial)
 	LOGDEBUG(F("> wifiDriverInit"));
 
 	EspDrv::espSerial = espSerial;
+	
+#ifdef WL_HARD_RESET_PIN
+	// Hard reset the ESP8266 to get it into a defined state 
+	pinMode(WL_HARD_RESET_PIN, OUTPUT);
+	digitalWrite(WL_HARD_RESET_PIN, LOW);
+	delay(500);
+	digitalWrite(WL_HARD_RESET_PIN, HIGH);
+#endif
 
 	bool initOK = false;
 	
@@ -115,8 +123,17 @@ void EspDrv::reset()
 {
 	LOGDEBUG(F("> reset"));
 
+#ifdef WL_HARD_RESET_PIN
+	// Issue a hard reset 
+	digitalWrite(WL_HARD_RESET_PIN, LOW);
+	delay(500);
+	digitalWrite(WL_HARD_RESET_PIN, HIGH);
+	delay(2500);
+#else
+	// Issue a soft reset
 	sendCmd(F("AT+RST"));
 	delay(3000);
+#endif
 	espEmptyBuf(false);  // empty dirty characters from the buffer
 
 	// disable echo of commands

--- a/src/utility/EspDrv.h
+++ b/src/utility/EspDrv.h
@@ -25,7 +25,14 @@ along with The Arduino WiFiEsp library.  If not, see
 
 #include "RingBuffer.h"
 
-
+/* 
+ * Pin for ESP8266 hard reset 
+ * Connect this to the ESP8266's CH_PD line (taking care of the voltage
+ * differential, either through a converter or through a resistor bridge,
+ * just like you did for the ESP8266's RX line)
+ * If undefined, we will be relying entirely on soft reset (AT+RST) 
+ */
+//#define WL_HARD_RESET_PIN 10
 
 // Maximum size of a SSID
 #define WL_SSID_MAX_LENGTH 32


### PR DESCRIPTION
A hard reset (as opposed to a soft reset through the `AT+RST` command) has the advantage that it works even when the ESP8266 is hung for some reason. This can be used for auto-resetting the ESP8266 by a watchdog, more reliably than through the AT interface.

To use this, you need to wire a dedicated pin of the Arduino to the ESP8266's ̀`CH_PD` line and `#define WL_HARD_RESET_PIN` in your code. Take the usual precautions regarding voltage (5V -> 3.3V), just as for the ESP8266's `RX` pin. If you use the [ESP8266 Wifi Shield](http://www.instructables.com/id/Cheap-Arduino-WiFi-Shield-With-ESP8266/), that means one extra 1K and 2.2K resistor each, and wiring up `CH_PD` to an Arduino pin instead of 3.3V.

The rationale for choosing the `CH_PD` instead of the `RST` line is explained by the analysis at https://hallard.me/esp8266-autoreset/. The author recommends `CH_PD` over `RST` for auto reset because of problems with how the `RST` line is apparently wired up internally.

Pin 10 is suggested in the code because it works nicely with AltSoftSerial - the library uses pins 8/9 for RX/TX and disables the PWM functionality of pin 10, leaving it usable only for digital I/O - but the specific pin does not really matter.