### PR TITLE
Clean up compiler warnings

### DIFF
--- a/src/utility/EspDrv.cpp
+++ b/src/utility/EspDrv.cpp
@@ -27,11 +27,11 @@ along with The Arduino WiFiEsp library.  If not, see
 
 const char* ESPTAGS[] =
 {
-    "\r\nOK\r\n",
+  "\r\nOK\r\n",
 	"\r\nERROR\r\n",
 	"\r\nFAIL\r\n",
-    "\r\nSEND OK\r\n",
-    " CONNECT\r\n"
+  "\r\nSEND OK\r\n",
+  " CONNECT\r\n"
 };
 
 typedef enum
@@ -74,7 +74,7 @@ void EspDrv::wifiDriverInit(Stream *espSerial)
 	EspDrv::espSerial = espSerial;
 
 	bool initOK = false;
-	
+
 	for(int i=0; i<5; i++)
 	{
 		if (sendCmd(F("AT")) == TAG_OK)
@@ -131,7 +131,7 @@ void EspDrv::reset()
 
 	// Show remote IP and port with "+IPD"
 	sendCmd(F("AT+CIPDINFO=1"));
-	
+
 	// Disable autoconnect
 	// Automatic connection can create problems during initialization phase at next boot
 	sendCmd(F("AT+CWAUTOCONN=0"));
@@ -194,7 +194,7 @@ bool EspDrv::wifiStartAP(const char* ssid, const char* pwd, uint8_t channel, uin
 		LOGWARN1(F("Failed to start AP"), ssid);
 		return false;
 	}
-	
+
 	if (espMode==2)
 		sendCmd(F("AT+CWDHCP_CUR=0,1"));    // enable DHCP for AP mode
 	if (espMode==3)
@@ -225,10 +225,10 @@ void EspDrv::config(IPAddress ip)
 
 	// disable station DHCP
 	sendCmd(F("AT+CWDHCP_CUR=1,0"));
-	
+
 	// it seems we need to wait here...
 	delay(500);
-	
+
 	char buf[16];
 	sprintf_P(buf, PSTR("%d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
 
@@ -244,15 +244,15 @@ void EspDrv::config(IPAddress ip)
 void EspDrv::configAP(IPAddress ip)
 {
 	LOGDEBUG(F("> config"));
-	
+
     sendCmd(F("AT+CWMODE_CUR=2"));
-	
+
 	// disable station DHCP
 	sendCmd(F("AT+CWDHCP_CUR=2,0"));
-	
+
 	// it seems we need to wait here...
 	delay(500);
-	
+
 	char buf[16];
 	sprintf_P(buf, PSTR("%d.%d.%d.%d"), ip[0], ip[1], ip[2], ip[3]);
 
@@ -456,26 +456,22 @@ int32_t EspDrv::getCurrentRSSI()
 
 uint8_t EspDrv::getScanNetworks()
 {
-    uint8_t ssidListNum = 0;
-    int idx;
-	bool ret = false;
-	
+	uint8_t ssidListNum = 0;
+	int idx;
 
 	espEmptyBuf();
 
 	LOGDEBUG(F("----------------------------------------------"));
 	LOGDEBUG(F(">> AT+CWLAP"));
-	
+
 	espSerial->println(F("AT+CWLAP"));
 
-	char buf[100];
-	
 	idx = readUntil(10000, "+CWLAP:(");
-	
+
 	while (idx == NUMESPTAGS)
 	{
 		_networkEncr[ssidListNum] = espSerial->parseInt();
-		
+
 		// discard , and " characters
 		readUntil(1000, "\"");
 
@@ -485,12 +481,12 @@ uint8_t EspDrv::getScanNetworks()
 			memset(_networkSsid[ssidListNum], 0, WL_SSID_MAX_LENGTH );
 			ringBuf.getStrN(_networkSsid[ssidListNum], 1, WL_SSID_MAX_LENGTH-1);
 		}
-		
+
 		// discard , character
 		readUntil(1000, ",");
-		
+
 		_networkRssi[ssidListNum] = espSerial->parseInt();
-		
+
 		idx = readUntil(1000, "+CWLAP:(");
 
 		if(ssidListNum==WL_NETWORKS_LIST_MAXNUM-1)
@@ -498,7 +494,7 @@ uint8_t EspDrv::getScanNetworks()
 
 		ssidListNum++;
 	}
-	
+
 	if (idx==-1)
 		return -1;
 
@@ -576,7 +572,7 @@ bool EspDrv::ping(const char *host)
 	LOGDEBUG(F("> ping"));
 
 	int ret = sendCmd(F("AT+PING=\"%s\""), 8000, host);
-	
+
 	if (ret==TAG_OK)
 		return true;
 
@@ -599,7 +595,7 @@ bool EspDrv::startServer(uint16_t port, uint8_t sock)
 bool EspDrv::startClient(const char* host, uint16_t port, uint8_t sock, uint8_t protMode)
 {
 	LOGDEBUG2(F("> startClient"), host, port);
-	
+
 	// TCP
 	// AT+CIPSTART=<link ID>,"TCP",<remote IP>,<remote port>
 
@@ -609,7 +605,7 @@ bool EspDrv::startClient(const char* host, uint16_t port, uint8_t sock, uint8_t 
 	// for UDP we set a dummy remote port and UDP mode to 2
 	// this allows to specify the target host/port in CIPSEND
 
-	int ret;
+	int ret = -1;
 	if (protMode==TCP_MODE)
 		ret = sendCmd(F("AT+CIPSTART=%d,\"TCP\",\"%s\",%u"), 5000, sock, host, port);
 	else if (protMode==SSL_MODE)
@@ -630,7 +626,7 @@ void EspDrv::stopClient(uint8_t sock)
 {
 	LOGDEBUG1(F("> stopClient"), sock);
 
-	int ret = sendCmd(F("AT+CIPCLOSE=%d"), 4000, sock);
+	sendCmd(F("AT+CIPCLOSE=%d"), 4000, sock);
 }
 
 
@@ -685,7 +681,7 @@ uint16_t EspDrv::availData(uint8_t connId)
 			espSerial->read();                  // "
 			espSerial->read();                  // ,
 			_remotePort = espSerial->parseInt();     // <remote port>
-			
+
 			espSerial->read();                  // :
 
 			LOGDEBUG();
@@ -762,7 +758,7 @@ bool EspDrv::getData(uint8_t connId, uint8_t *data, bool peek, bool* connClose)
     _bufPos = 0;
 	_connId = 0;
 	*data = 0;
-	
+
 	return false;
 }
 
@@ -778,14 +774,14 @@ int EspDrv::getDataBuf(uint8_t connId, uint8_t *buf, uint16_t bufSize)
 
 	if(_bufPos<bufSize)
 		bufSize = _bufPos;
-	
+
 	for(int i=0; i<bufSize; i++)
 	{
 		int c = timedRead();
 		//LOGDEBUG(c);
 		if(c==-1)
 			return -1;
-		
+
 		buf[i] = (char)c;
 		_bufPos--;
 	}
@@ -1041,7 +1037,7 @@ int EspDrv::sendCmd(const __FlashStringHelper* cmd, int timeout, ...)
 // Returns:
 //   the index of the tag found in the ESPTAGS array
 //   -1 if no tag was found (timeout)
-int EspDrv::readUntil(int timeout, const char* tag, bool findTags)
+int EspDrv::readUntil(unsigned int timeout, const char* tag, bool findTags)
 {
 	ringBuf.reset();
 
@@ -1110,7 +1106,7 @@ void EspDrv::espEmptyBuf(bool warn)
 // copied from Serial::timedRead
 int EspDrv::timedRead()
 {
-  int _timeout = 1000;
+  unsigned int _timeout = 1000;
   int c;
   long _startMillis = millis();
   do

--- a/src/utility/EspDrv.h
+++ b/src/utility/EspDrv.h
@@ -322,7 +322,7 @@ private:
 	static bool sendCmdGet(const __FlashStringHelper* cmd, const char* startTag, const char* endTag, char* outStr, int outStrLen);
 	static bool sendCmdGet(const __FlashStringHelper* cmd, const __FlashStringHelper* startTag, const __FlashStringHelper* endTag, char* outStr, int outStrLen);
 
-	static int readUntil(int timeout, const char* tag=NULL, bool findTags=true);
+	static int readUntil(unsigned int timeout, const char* tag=NULL, bool findTags=true);
 
 	static void espEmptyBuf(bool warn=true);
 


### PR DESCRIPTION
The compiler complains about comparisons between signed and unsigned integers. This comparison is between the (unsigned) current time and a (signed) timeout time. Negative timeouts do not exist, so that warning can be resolved very easily.
Moreover, the compiler warns about some unused variables that are also removed in this pull request.
Lastly the compiler gives a warning about a variable that possibly has not been assigned, this is resolved by initializing it with -1.