### PR TITLE
Fixed compile errors for STM32 boards

### DIFF
--- a/src/WiFiEspClient.cpp
+++ b/src/WiFiEspClient.cpp
@@ -43,14 +43,14 @@ WiFiEspClient::WiFiEspClient(uint8_t sock) : _sock(sock)
 // this is very slow on ESP
 size_t WiFiEspClient::print(const __FlashStringHelper *ifsh)
 {
-	printFSH(ifsh, false);
+	return printFSH(ifsh, false);
 }
 
 // if we do override this, the standard println will call the print
 // method twice
 size_t WiFiEspClient::println(const __FlashStringHelper *ifsh)
 {
-	printFSH(ifsh, true);
+	return printFSH(ifsh, true);
 }
 
 

--- a/src/utility/EspDrv.cpp
+++ b/src/utility/EspDrv.cpp
@@ -22,6 +22,13 @@ along with The Arduino WiFiEsp library.  If not, see
 #include "utility/EspDrv.h"
 #include "utility/debug.h"
 
+#if defined(ARDUINO_ARCH_STM32)
+//For va_start
+#include <stdarg.h>
+
+//vsnprintf_P is not defined in avr/pgmspace.h for ststm32-maple
+#define vsnprintf_P vsnprintf
+#endif
 
 #define NUMESPTAGS 5
 

--- a/src/utility/RingBuffer.cpp
+++ b/src/utility/RingBuffer.cpp
@@ -92,7 +92,7 @@ void RingBuffer::getStr(char * destination, unsigned int skipChars)
 
 void RingBuffer::getStrN(char * destination, unsigned int skipChars, unsigned int num)
 {
-	int len = ringBufP-ringBuf-skipChars;
+	unsigned int len = ringBufP-ringBuf-skipChars;
 
 	if (len>num)
 		len=num;


### PR DESCRIPTION
For stm32 (like the STM32F103C8T6 aka BluePill) we need to manually include stdarg.h.
Also avr/pgmspace.h does not define vsnprintf_P so this has to be done manually.

In the second commit I fixed some compiler warnings. There´s still 2 left though regarding a possible buffer overflow in EspDrv::sendData:

```

.piolibdeps\WiFiEsp\src\utility\EspDrv.cpp: In static member function 'static bool EspDrv::sendData(uint8_t, const uint8_t*, uint16_t)':
.piolibdeps\WiFiEsp\src\utility\EspDrv.cpp:803:6: warning: 'sprintf' may write a terminating nul past the end of the destination [-Wformat-overflow=]
bool EspDrv::sendData(uint8_t sock, const uint8_t *data, uint16_t len)
^~~~~~
In file included from C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/WString.h:29:0,
from C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/wirish.h:47,
from C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/Arduino.h:30,
from .piolibdeps\WiFiEsp\src\utility\EspDrv.cpp:19:
C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/avr/pgmspace.h:28:37: note: 'sprintf' output between 15 and 21 bytes into a destination of size 20
#define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
.piolibdeps\WiFiEsp\src\utility\EspDrv.cpp:808:2: note: in expansion of macro 'sprintf_P'
sprintf_P(cmdBuf, PSTR("AT+CIPSEND=%d,%u"), sock, len);
^~~~~~~~~
.piolibdeps\WiFiEsp\src\utility\EspDrv.cpp: In static member function 'static bool EspDrv::sendData(uint8_t, const __FlashStringHelper*, uint16_t, bool)':
.piolibdeps\WiFiEsp\src\utility\EspDrv.cpp:831:6: warning: 'sprintf' may write a terminating nul past the end of the destination [-Wformat-overflow=]
bool EspDrv::sendData(uint8_t sock, const __FlashStringHelper *data, uint16_t len, bool appendCrLf)
^~~~~~
In file included from C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/WString.h:29:0,
from C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/wirish.h:47,
from C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/Arduino.h:30,
from .piolibdeps\WiFiEsp\src\utility\EspDrv.cpp:19:
C:\users\sebif\.platformio\packages\framework-arduinoststm32-maple\STM32F1\cores\maple/avr/pgmspace.h:28:37: note: 'sprintf' output between 15 and 21 bytes into a destination of size 20
#define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
.piolibdeps\WiFiEsp\src\utility\EspDrv.cpp:837:2: note: in expansion of macro 'sprintf_P'
sprintf_P(cmdBuf, PSTR("AT+CIPSEND=%d,%u"), sock, len2);
^~~~~~~~~
```