### PR TITLE
Update WiFiEspClient.cpp because of compile error only small changes

### DIFF
--- a/src/WiFiEspClient.cpp
+++ b/src/WiFiEspClient.cpp
@@ -43,14 +43,14 @@ WiFiEspClient::WiFiEspClient(uint8_t sock) : _sock(sock)
 // this is very slow on ESP
 size_t WiFiEspClient::print(const __FlashStringHelper *ifsh)
 {
-	printFSH(ifsh, false);
+	return printFSH(ifsh, false);
 }
 
 // if we do override this, the standard println will call the print
 // method twice
 size_t WiFiEspClient::println(const __FlashStringHelper *ifsh)
 {
-	printFSH(ifsh, true);
+	return printFSH(ifsh, true);
 }
 
 


### PR DESCRIPTION
Building nodemcu fails because of .pio\libdeps\nodemcu\WiFiEsp\src\WiFiEspClient.cpp:47:1: error: no return statement in function returning non-void [-Werror=return-type]

Return statement missing.