### PR TITLE
WebClient example: Old url didn't support http anymore

### DIFF
--- a/examples/WebClient/WebClient.ino
+++ b/examples/WebClient/WebClient.ino
@@ -19,7 +19,7 @@ char ssid[] = "Twim";            // your network SSID (name)
 char pass[] = "12345678";        // your network password
 int status = WL_IDLE_STATUS;     // the Wifi radio's status
 
-char server[] = "arduino.cc";
+char server[] = "arduino.tips";
 
 // Initialize the Ethernet client object
 WiFiEspClient client;
@@ -60,7 +60,7 @@ void setup()
     Serial.println("Connected to server");
     // Make a HTTP request
     client.println("GET /asciilogo.txt HTTP/1.1");
-    client.println("Host: arduino.cc");
+    client.println("Host: arduino.tips");
     client.println("Connection: close");
     client.println();
   }


### PR DESCRIPTION
The old url now redirects to the https version of the page, resulting on this example, which was made to show the capability to connect to http servers, not showing the logo. The old url shows a message which suggests to use this new link if a http compatible version of this logo is needed, just as it is in this case.